### PR TITLE
Miscellany

### DIFF
--- a/schedcat/distributor/rpc.py
+++ b/schedcat/distributor/rpc.py
@@ -292,10 +292,9 @@ class ExperimentManager(pb.Root):
                 remaining = self.checker.remaining(dp)
                 by_time = int((self.min_block_time * dp.samples) / dp.elapsed)
                 trials = max(remaining // 2, by_time)
-            return dp.params, trials
-
+            return dp.params, trials, self.experiment.metrics
         else:
-            return None, 0
+            return None, 0, 0
 
     def remote_record_data(self, dp, trials, elapsed, results):
         dpo = self.outstanding[dict_to_key(dp)]
@@ -380,10 +379,10 @@ class SchedulabilityClient(object):
         next.addErrback(self.broken)
         self.backlog += 1
 
-    def process_design_point(self, (dp_dict, trials)):
+    def process_design_point(self, (dp_dict, trials, metrics)):
         self.backlog -= 1
         if dp_dict:
-            dp = self.DesignPointRunner(trials, **dp_dict)
+            dp = self.DesignPointRunner(trials, metrics, **dp_dict)
             elapsed, results = dp.run()
             self.count += 1
             self.manager.callRemote("record_data", dp_dict, trials, elapsed, results)

--- a/schedcat/distributor/rpc.py
+++ b/schedcat/distributor/rpc.py
@@ -342,8 +342,8 @@ class ExperimentManager(pb.Root):
         return "Estimated time remaining: before - {}s, after - {}s".format(before, after)
 
 class SchedulabilityClient(object):
-    def __init__(self, dpfactory, server, port, local_buffer = 2):
-        self.dpfactory = dpfactory
+    def __init__(self, DesignPointRunner, server, port, local_buffer = 2):
+        self.DesignPointRunner = DesignPointRunner
 
         factory = pb.PBClientFactory()
         reactor.connectTCP(server, port, factory)
@@ -374,7 +374,7 @@ class SchedulabilityClient(object):
     def process_design_point(self, (dp_dict, trials)):
         self.backlog -= 1
         if dp_dict:
-            dp = self.dpfactory.build_design_point(trials, **dp_dict)
+            dp = self.DesignPointRunner(trials, **dp_dict)
             elapsed, results = dp.run()
             self.count += 1
             self.manager.callRemote("record_data", dp_dict, trials, elapsed, results)


### PR DESCRIPTION
How to adjust your existing client/server for these changes:
1. DesignPointRunner.**init**() is now called with an additional parameter, the metrics for that particular design point, so they do not have to be hard-coded or assumed in DesignPointRunner.
2. You can remove the design point factory code from the client. It seems to be unnecessary, so I removed it.
3. Client parameter feature, explained in detail below.

Client parameter feature:

You can define a dictionary in the server and pass it to ExperimentManager as an optional parameter. This dictionary can then be received on the client side when the client starts up.

To receive the dictionary, you need to write a function that accepts one param and stores it (probably as a global, so it can later be accessed from DesignPointRunner). You need to pass that function to SchedulabilityClient.

If and only if you have done so, SchedulabilityClient will ask the server to send the dictionary. When it does so, the function will be called with the dictionary specified in the server as the parameter.
